### PR TITLE
Added go_coverage for medium tests

### DIFF
--- a/moduleroot/scripts/test.sh
+++ b/moduleroot/scripts/test.sh
@@ -84,7 +84,8 @@ elif [[ $TEST_TYPE == "medium" ]]; then
   if [[ -f "${__dir}/medium.sh" ]]; then
     . "${__dir}/medium.sh"
   else
-    UNIT_TEST="go_test"
+    UNIT_TEST="go_test go_cover"
+    echo "mode: count" > profile.cov
     test_unit
   fi
 elif [[ $TEST_TYPE == "large" ]]; then


### PR DESCRIPTION
Show tests coverage for medium tests

### Summary of changes:
- for medium tests added making `go_convey`, results available in profile.cov 

### How to verify it:
- run cmd `scripts/tests.sh medium`

### Testing done:
- medium tests

Related with:
 - issue https://github.com/intelsdi-x/snap-plugin-collector-mysql/issues/23 
- and pull request https://github.com/intelsdi-x/snap-plugin-collector-mysql/pull/24 which fixed the issue

cc: @nanliu 