### PR TITLE
Fix #53 Add build all and remove extra build opts

### DIFF
--- a/moduleroot/.pluginsync.yml
+++ b/moduleroot/.pluginsync.yml
@@ -16,6 +16,6 @@ sync_yml = YAML.load_file("modules/#{@configs[:puppet_module]}/.sync.yml") rescu
 managed_files = managed_files.reject{|f| sync_yml.include? f and sync_yml[f]["unmanaged"] }
 -%>
 # File managed by pluginsync
-pluginsync_config: '0.1.11'
+pluginsync_config: '0.1.12'
 managed_files:
 <%= pad_yaml(managed_files) %>

--- a/moduleroot/Makefile
+++ b/moduleroot/Makefile
@@ -31,7 +31,11 @@ test-medium:
 	bash -c "./scripts/test.sh medium"
 test-large:
 	bash -c "./scripts/test.sh large"
+test-all:
+	$(MAKE) test-small
+	$(MAKE) test-medium
+	$(MAKE) test-large
 check:
 	$(MAKE) test
 all:
-	bash -c "./scripts/build.sh $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))"
+	bash -c "./scripts/build.sh"

--- a/moduleroot/scripts/test/large_spec.rb
+++ b/moduleroot/scripts/test/large_spec.rb
@@ -20,7 +20,7 @@ describe docker_compose(compose_yml) do
         }
       end
 
-      if os[:family] != 'ubuntu'
+      if os[:family] == 'alpine'
         describe port(8181) do
           it { should be_listening }
         end


### PR DESCRIPTION
* Use port check only on systems that have packages available
* Add build all options
* Remove extra build flags that we do not use