### PR TITLE
snap task check needs short delay.

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,7 @@ services:
 
 The default `large_spec.rb` test will verify all yaml example tasks in the plugin's `examples/task` folder. The large test ignores json tasks, so they can be used as examples to demonstrate features that are not tested. There are no restrictions when you write custom tests, and here's some recommendations:
 
+* examples tasks _must_ set `max-failures: 1` because we only check if a task is in running state, higher max-failures values will mask failures since it takes multiple collect attempts to toggle the task to disabled state.
 * avoid using mock plugins whenever possible
 * when mock plugins are required, download the appropriate binary in the build directory (mock vs. mock2)
 * use a fixtures directory to simulate the content of the `/proc` directory instead of depending on the test system

--- a/moduleroot/scripts/test/large_spec.rb
+++ b/moduleroot/scripts/test/large_spec.rb
@@ -65,6 +65,8 @@ describe docker_compose(compose_yml) do
               id = subject.stdout.split("\n").find{|l|l=~/^ID:/}
               task_id = $1 if id.match(/^ID: (.*)$/)
               expect(task_id).to_not be_nil
+              # NOTE we need a short pause before checking task state in case it fails:
+              sleep 3
             }
           end
 


### PR DESCRIPTION
* we need a delay to give tasks time to toggle from running to disabled state.
* add warning about task's max-failure setting