### PR TITLE
Fixed code blocks in CONTRIBUTING.md

### DIFF
--- a/moduleroot/CONTRIBUTING.md
+++ b/moduleroot/CONTRIBUTING.md
@@ -25,15 +25,15 @@ Once you're ready to contribute code back to this repo, start with these steps:
 * Fork the appropriate sub-projects that are affected by your change.
 * Clone the fork to `$GOPATH/src/github.com/intelsdi-x/`:
 
-    ```
+  ```
 $ cd "${GOPATH}/src/github.com/intelsdi-x/"
 $ git clone https://github.com/intelsdi-x/<%= repo_name %>.git
-    ```
+  ```
 * Create a topic branch for your change and checkout that branch:
 
-    ```
+  ```
 $ git checkout -b some-topic-branch
-    ```
+  ```
 * Make your changes to the code and add tests to cover contributed code.
 * Validate the changes and run the test suite if one is provided.
 * Commit your changes and push them to your fork.

--- a/moduleroot/CONTRIBUTING.md
+++ b/moduleroot/CONTRIBUTING.md
@@ -24,15 +24,13 @@ Once you're ready to contribute code back to this repo, start with these steps:
 
 * Fork the appropriate sub-projects that are affected by your change.
 * Clone the fork to `$GOPATH/src/github.com/intelsdi-x/`:
-
   ```
-$ cd "${GOPATH}/src/github.com/intelsdi-x/"
-$ git clone https://github.com/intelsdi-x/<%= repo_name %>.git
+  $ cd "${GOPATH}/src/github.com/intelsdi-x/"
+  $ git clone https://github.com/intelsdi-x/<%= repo_name %>.git
   ```
 * Create a topic branch for your change and checkout that branch:
-
   ```
-$ git checkout -b some-topic-branch
+  $ git checkout -b some-topic-branch
   ```
 * Make your changes to the code and add tests to cover contributed code.
 * Validate the changes and run the test suite if one is provided.


### PR DESCRIPTION
Fixes broken code blocks in CONTRIBUTING.md.
It looks even more broken in GitHub preview after changes (I guess some problem with escaping template characters), but after running sync it generates proper code blocks.