### PR TITLE
Removing list syntax from CI badges

### DIFF
--- a/lib/pluginsync/util.rb
+++ b/lib/pluginsync/util.rb
@@ -130,6 +130,7 @@ module Pluginsync
         'pcm': 'PCM',
         'psutil': 'PSUtil',
         'rabbitmq': 'RabbitMQ',
+        'rdt': 'RDT',
         'snmp': 'SNMP',
         'use': 'USE',
       }[word.to_sym] || word.slice(0,1).capitalize + word.slice(1..-1)

--- a/lib/pluginsync/util.rb
+++ b/lib/pluginsync/util.rb
@@ -139,8 +139,8 @@ module Pluginsync
       case list
       when ::Array
         if list.size > 1
-          items = list.collect{|i| "<li>#{i}</li>"}.join('')
-          "<ul>#{items}</ul>"
+          items = list.collect{|i| "#{i}"}.join(' ')
+          "#{items}"
         else
           "#{list.first}"
         end

--- a/lib/pluginsync/util.rb
+++ b/lib/pluginsync/util.rb
@@ -137,14 +137,8 @@ module Pluginsync
     end
 
     def self.html_list(list)
-      case list
-      when ::Array
-        if list.size > 1
-          items = list.collect{|i| "#{i}"}.join(' ')
-          "#{items}"
-        else
-          "#{list.first}"
-        end
+      if list.is_a? ::Array 
+        list.join(' ')
       else
         list
       end


### PR DESCRIPTION
List view renders incredibly small and badges stack quite nicely on top of each other. This may have changed when GitHub updated how they render markdown, so its a good time to adjust here.