### PR TITLE
Fix host IP resolving for docker container

### DIFF
--- a/pluginsync.sh
+++ b/pluginsync.sh
@@ -28,7 +28,15 @@ fi
 # https://github.com/docker/for-mac/issues/483
 socat TCP-LISTEN:"$PORT",reuseaddr,fork,bind=127.0.0.1 UNIX-CLIENT:"$SSH_AUTH_SOCK" &
 
+# Set host address based on system
+PLATFORM=$(uname -s)
+if [[ $PLATFORM == 'Darwin' ]]; then
+  HOST='192.168.65.1'
+else
+  HOST='127.0.0.1'
+fi
+
 docker pull intelsdi/pluginsync
-docker run --net=host -v "${HOME}":/root -v "$(pwd)":/plugins -e SSH_AUTH_SOCK=/var/run/ssh_agent.sock  -it intelsdi/pluginsync /bin/bash -c "socat UNIX-LISTEN:/var/run/ssh_agent.sock,reuseaddr,fork TCP:192.168.65.1:${PORT} & cd /plugins && echo 'commands do not be prefixed with bundle exec, try: \"rake -T\" or \"travis\" or \"msync\"' && /bin/bash"
+docker run --net=host -v "${HOME}":/root -v "$(pwd)":/plugins -e SSH_AUTH_SOCK=/var/run/ssh_agent.sock  -it intelsdi/pluginsync /bin/bash -c "socat UNIX-LISTEN:/var/run/ssh_agent.sock,reuseaddr,fork TCP:$HOST:$PORT & cd /plugins && echo 'commands do not be prefixed with bundle exec, try: \"rake -T\" or \"travis\" or \"msync\"' && /bin/bash"
 
 exit 0


### PR DESCRIPTION
Right now, pluginsync docker container works out of the box only on Mac, as address for container to access host at is set to `192.168.65.1`, which is specific to Docker for Mac.
This PR adds behaviour that sets host IP based on platform, which allows using pluginsync on both Mac and Linux, without modifying `pluginsync.sh`.

Resolves #76 